### PR TITLE
Consul config option

### DIFF
--- a/modules/run-nomad/run-nomad
+++ b/modules/run-nomad/run-nomad
@@ -33,6 +33,7 @@ function print_usage {
   echo -e "  --use-sudo\t\tIf set, run the Nomad agent with sudo. By default, sudo is only used if --client is set."
   echo -e "  --node-class\t\tThe class of the client node for use with job placement. Only used if --client is set."
   echo -e "  --environment\t\A single environment variable in the key/value pair form 'KEY=\"val\"' to pass to Nomad as environment variable when starting it up. Repeat this option for additional variables. Optional."
+  echo -e "  --skip-consul-config\tIf this flag is set, don't add Consul configuration to the Nomad configuration file. Default is false."
   echo -e "  --skip-nomad-config\tIf this flag is set, don't generate a Nomad configuration file. Optional. Default is false."
   echo
   echo "Example:"
@@ -131,7 +132,8 @@ function generate_nomad_config {
   local readonly datacenter="${4}"
   local readonly num_servers="${5}"
   local readonly node_class="${6}"
-  local readonly config_dir="${7}"
+  local readonly skip_consul="${7}"
+  local readonly config_dir="${8}"
   local readonly config_path="$config_dir/$NOMAD_CONFIG_FILE"
 
   local instance_id=""
@@ -174,6 +176,16 @@ EOF
 )
   fi
 
+  local consul_config=$(cat <<EOF
+consul {
+  address = "127.0.0.1:8500"
+}
+EOF
+)
+  if [[ "$skip_consul" == "true" ]]; then
+    consul_config=""
+  fi
+
   log_info "Creating default Nomad config file in $config_path"
   cat > "$config_path" <<EOF
 datacenter = "$datacenter"
@@ -191,9 +203,7 @@ $client_config
 
 $server_config
 
-consul {
-  address = "127.0.0.1:8500"
-}
+$consul_config
 EOF
   chown "$user:$user" "$config_path"
 }
@@ -287,6 +297,7 @@ function run {
   local systemd_stderr=""
   local user=""
   local datacenter=""
+  local skip_consul_config="false"
   local skip_nomad_config="false"
   local use_sudo=""
   local node_class=""
@@ -351,6 +362,9 @@ function run {
         assert_not_empty "$key" "$2"
         datacenter="$2"
         shift
+        ;;
+      --skip-consul-config)
+        skip_consul_config="true"
         ;;
       --skip-nomad-config)
         skip_nomad_config="true"
@@ -435,6 +449,7 @@ function run {
       "$datacenter" \
       "$num_servers" \
       "$node_class" \
+      "$skip_consul_config" \
       "$config_dir"
   fi
 


### PR DESCRIPTION
Add a --skip-consul-config to omit the Consul configuration section from the generated Nomad configuration file.